### PR TITLE
Add team ranking order

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # my_first_project
-First Project
+
+Simple KBO team fan board built with Flask.
+
+Each team has a message board where fans can post a title, content and an optional
+file attachment. Posts are listed with their titles and authors; clicking a title
+shows the full post.
+
+On the home page, the list of teams is ordered by the current KBO team ranking.
+The app attempts to fetch the ranking from `koreabaseball.com` and falls back to
+a default order if the site cannot be reached.
+
+## Setup
+```
+pip install -r requirements.txt
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,116 @@
+from flask import Flask, render_template, request, redirect, url_for
+from werkzeug.utils import secure_filename
+from bs4 import BeautifulSoup
+import requests
+import os
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
+
+# simple in-memory storage for posts
+posts = {}
+
+# list of KBO teams (fallback order)
+DEFAULT_TEAMS = [
+    'Doosan Bears',
+    'Lotte Giants',
+    'Hanwha Eagles',
+    'LG Twins',
+    'SSG Landers',
+    'Samsung Lions',
+    'KIA Tigers',
+    'KT Wiz',
+    'NC Dinos',
+    'Kiwoom Heroes'
+]
+
+# mapping from Korean team names on the ranking page to our board names
+TEAM_NAME_MAP = {
+    '두산': 'Doosan Bears',
+    '롯데': 'Lotte Giants',
+    '한화': 'Hanwha Eagles',
+    'LG': 'LG Twins',
+    'SSG': 'SSG Landers',
+    '삼성': 'Samsung Lions',
+    'KIA': 'KIA Tigers',
+    'KT': 'KT Wiz',
+    'NC': 'NC Dinos',
+    '키움': 'Kiwoom Heroes'
+}
+
+
+def fetch_ranked_teams():
+    """Attempt to fetch team rankings from the KBO website."""
+    url = 'https://www.koreabaseball.com/Record/TeamRank/TeamRank.aspx'
+    try:
+        resp = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}, timeout=5)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        teams = []
+        table = soup.find('table', {'class': 'tData'})
+        if table:
+            for row in table.select('tbody tr'):
+                cols = row.find_all('td')
+                if cols:
+                    name_ko = cols[1].get_text(strip=True)
+                    teams.append(TEAM_NAME_MAP.get(name_ko, name_ko))
+        if teams:
+            return teams
+    except Exception as exc:
+        print('Failed to fetch rankings:', exc)
+    return DEFAULT_TEAMS
+
+
+def get_ranked_teams():
+    if not hasattr(get_ranked_teams, 'cache'):
+        get_ranked_teams.cache = fetch_ranked_teams()
+    return get_ranked_teams.cache
+
+@app.route('/')
+def index():
+    teams = get_ranked_teams()
+    return render_template('index.html', teams=teams)
+
+@app.route('/team/<team>', methods=['GET', 'POST'])
+def team_board(team):
+    teams = get_ranked_teams()
+    if team not in teams:
+        return "Unknown team", 404
+
+    if request.method == 'POST':
+        title = request.form.get('title', '').strip()
+        username = request.form.get('username', 'Anonymous').strip() or 'Anonymous'
+        content = request.form.get('content', '')
+        file = request.files.get('file')
+        filename = None
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            team_folder = os.path.join(app.config['UPLOAD_FOLDER'], team)
+            os.makedirs(team_folder, exist_ok=True)
+            file.save(os.path.join(team_folder, filename))
+
+        posts.setdefault(team, []).append({
+            'title': title or 'No Title',
+            'username': username,
+            'content': content,
+            'filename': filename
+        })
+        return redirect(url_for('team_board', team=team))
+
+    team_posts = posts.get(team, [])
+    return render_template('team.html', team=team, posts=team_posts)
+
+
+@app.route('/team/<team>/post/<int:post_id>')
+def view_post(team, post_id):
+    teams = get_ranked_teams()
+    if team not in teams:
+        return "Unknown team", 404
+    team_posts = posts.get(team, [])
+    if post_id < 0 or post_id >= len(team_posts):
+        return "Post not found", 404
+    post = team_posts[post_id]
+    return render_template('post.html', team=team, post=post)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+werkzeug
+requests
+beautifulsoup4

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,7 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+.teams { display: block; }
+.team { margin: 10px 0; text-align: center; }
+.icon { width: 80px; height: 80px; background: #ccc; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 32px; margin-bottom: 5px; }
+.post { border: 1px solid #ccc; padding: 10px; margin: 10px 0; }
+.posts { border-collapse: collapse; width: 100%; margin-top: 10px; }
+.posts th, .posts td { border: 1px solid #ccc; padding: 8px; text-align: left; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>KBO Fan Boards</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <h1>KBO Teams</h1>
+    <div class="teams">
+    {% for team in teams %}
+        <div class="team">
+            <a href="{{ url_for('team_board', team=team) }}">
+                <div class="icon">{{ team.split()[0][0] }}</div>
+                <div class="name">{{ team }}</div>
+            </a>
+        </div>
+    {% endfor %}
+    </div>
+</body>
+</html>

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ post.title }}</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <h1>{{ post.title }}</h1>
+    <p><strong>Author:</strong> {{ post.username }}</p>
+    <p>{{ post.content }}</p>
+    {% if post.filename %}
+        <p>Attachment: <a href="{{ url_for('static', filename='uploads/' + team + '/' + post.filename) }}">{{ post.filename }}</a></p>
+    {% endif %}
+    <a href="{{ url_for('team_board', team=team) }}">Back to Board</a>
+</body>
+</html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ team }} Board</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <h1>{{ team }} Fan Board</h1>
+    <a href="/">Back to Teams</a>
+
+    <h2>New Post</h2>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="text" name="title" placeholder="Title"><br>
+        <input type="text" name="username" placeholder="Your name"><br>
+        <textarea name="content" placeholder="Write your post"></textarea><br>
+        <input type="file" name="file"><br>
+        <button type="submit">Submit</button>
+    </form>
+
+    <h2>Posts</h2>
+    <table class="posts">
+        <tr><th>Title</th><th>Author</th></tr>
+        {% for post in posts %}
+            <tr>
+                <td><a href="{{ url_for('view_post', team=team, post_id=loop.index0) }}">{{ post.title }}</a></td>
+                <td>{{ post.username }}</td>
+            </tr>
+        {% else %}
+            <tr><td colspan="2">No posts yet.</td></tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- crawl KBO team rankings and sort teams accordingly
- show teams vertically in ranking order
- mention ranking fetch in README
- include requests and BeautifulSoup dependencies

## Testing
- `python3 -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877a5f48e388321a6c2d6aa1a68a662