### PR TITLE
Add KBO fan boards with login and centered logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # my_first_project
-First Project
+
+Simple KBO team fan board built with Flask.
+
+## Features
+- Lists KBO teams in live ranking order using data from `koreabaseball.com`
+- Team boards let fans post a title, content and optional file attachment
+- Posts are listed by title and author; clicking a title shows the full post
+- Simple login and sign‑up allow users to register with an ID, password and nickname
+- Team list shows each club logo and links to its board
+
+## Setup
+```
+pip install -r requirements.txt
+python app.py
+```
+
+Visit `http://localhost:5000` in your browser.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,173 @@
+from flask import Flask, render_template, request, redirect, url_for, session
+from werkzeug.utils import secure_filename
+from bs4 import BeautifulSoup
+import requests
+import os
+
+app = Flask(__name__)
+app.config['UPLOAD_FOLDER'] = os.path.join('static', 'uploads')
+app.secret_key = 'secret-key'
+
+# simple in-memory storage for posts and users
+posts = {}
+users = {}
+
+# list of KBO teams (fallback order)
+DEFAULT_TEAMS = [
+    'Doosan Bears',
+    'Lotte Giants',
+    'Hanwha Eagles',
+    'LG Twins',
+    'SSG Landers',
+    'Samsung Lions',
+    'KIA Tigers',
+    'KT Wiz',
+    'NC Dinos',
+    'Kiwoom Heroes'
+]
+
+# mapping from Korean team names on the ranking page to our board names
+TEAM_NAME_MAP = {
+    '두산': 'Doosan Bears',
+    '롯데': 'Lotte Giants',
+    '한화': 'Hanwha Eagles',
+    'LG': 'LG Twins',
+    'SSG': 'SSG Landers',
+    '삼성': 'Samsung Lions',
+    'KIA': 'KIA Tigers',
+    'KT': 'KT Wiz',
+    'NC': 'NC Dinos',
+    '키움': 'Kiwoom Heroes'
+}
+
+# simple logo mapping (public URLs)
+TEAM_LOGOS = {
+    'Doosan Bears': 'https://sports-phinf.pstatic.net/team/kbo/default/OB.png',
+    'Lotte Giants': 'https://sports-phinf.pstatic.net/team/kbo/default/LT.png',
+    'Hanwha Eagles': 'https://sports-phinf.pstatic.net/team/kbo/default/HH.png',
+    'LG Twins': 'https://sports-phinf.pstatic.net/team/kbo/default/LG.png',
+    'SSG Landers': 'https://sports-phinf.pstatic.net/team/kbo/default/SK.png',
+    'Samsung Lions': 'https://sports-phinf.pstatic.net/team/kbo/default/SS.png',
+    'KIA Tigers': 'https://sports-phinf.pstatic.net/team/kbo/default/HT.png',
+    'KT Wiz': 'https://sports-phinf.pstatic.net/team/kbo/default/KT.png',
+    'NC Dinos': 'https://sports-phinf.pstatic.net/team/kbo/default/NC.png',
+    'Kiwoom Heroes': 'https://sports-phinf.pstatic.net/team/kbo/default/WO.png'
+}
+
+
+def fetch_ranked_teams():
+    """Attempt to fetch team rankings from the KBO website."""
+    url = 'https://www.koreabaseball.com/Record/TeamRank/TeamRank.aspx'
+    try:
+        resp = requests.get(url, headers={'User-Agent': 'Mozilla/5.0'}, timeout=5)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        teams = []
+        table = soup.find('table', {'class': 'tData'})
+        if table:
+            for row in table.select('tbody tr'):
+                cols = row.find_all('td')
+                if cols:
+                    name_ko = cols[1].get_text(strip=True)
+                    teams.append(TEAM_NAME_MAP.get(name_ko, name_ko))
+        if teams:
+            return teams
+    except Exception as exc:
+        print('Failed to fetch rankings:', exc)
+    return DEFAULT_TEAMS
+
+
+def get_ranked_teams():
+    if not hasattr(get_ranked_teams, 'cache'):
+        get_ranked_teams.cache = fetch_ranked_teams()
+    return get_ranked_teams.cache
+
+@app.route('/')
+def index():
+    teams = get_ranked_teams()
+    nickname = session.get('nickname')
+    return render_template('index.html', teams=teams, logos=TEAM_LOGOS, nickname=nickname)
+
+@app.route('/team/<team>', methods=['GET', 'POST'])
+def team_board(team):
+    teams = get_ranked_teams()
+    if team not in teams:
+        return "Unknown team", 404
+
+    if request.method == 'POST':
+        title = request.form.get('title', '').strip()
+        username = session.get('nickname') or request.form.get('username', 'Anonymous').strip() or 'Anonymous'
+        content = request.form.get('content', '')
+        file = request.files.get('file')
+        filename = None
+        if file and file.filename:
+            filename = secure_filename(file.filename)
+            team_folder = os.path.join(app.config['UPLOAD_FOLDER'], team)
+            os.makedirs(team_folder, exist_ok=True)
+            file.save(os.path.join(team_folder, filename))
+
+        posts.setdefault(team, []).append({
+            'title': title or 'No Title',
+            'username': username,
+            'content': content,
+            'filename': filename
+        })
+        return redirect(url_for('team_board', team=team))
+
+    team_posts = posts.get(team, [])
+    nickname = session.get('nickname')
+    return render_template('team.html', team=team, posts=team_posts, nickname=nickname)
+
+
+@app.route('/team/<team>/post/<int:post_id>')
+def view_post(team, post_id):
+    teams = get_ranked_teams()
+    if team not in teams:
+        return "Unknown team", 404
+    team_posts = posts.get(team, [])
+    if post_id < 0 or post_id >= len(team_posts):
+        return "Post not found", 404
+    post = team_posts[post_id]
+    nickname = session.get('nickname')
+    return render_template('post.html', team=team, post=post, nickname=nickname)
+
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    error = None
+    if request.method == 'POST':
+        user_id = request.form.get('id', '').strip()
+        password = request.form.get('password', '')
+        user = users.get(user_id)
+        if user and user['password'] == password:
+            session['user'] = user_id
+            session['nickname'] = user['nickname']
+            return redirect(url_for('index'))
+        error = 'Invalid credentials'
+    return render_template('login.html', error=error)
+
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    error = None
+    if request.method == 'POST':
+        user_id = request.form.get('id', '').strip()
+        password = request.form.get('password', '')
+        nickname = request.form.get('nickname', '').strip()
+        if not user_id or user_id in users:
+            error = 'ID already exists'
+        else:
+            users[user_id] = {'password': password, 'nickname': nickname or user_id}
+            session['user'] = user_id
+            session['nickname'] = users[user_id]['nickname']
+            return redirect(url_for('index'))
+    return render_template('register.html', error=error)
+
+
+@app.route('/logout')
+def logout():
+    session.clear()
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+werkzeug
+requests
+beautifulsoup4

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,0 +1,9 @@
+body { font-family: Arial, sans-serif; margin: 20px; }
+.header { display: flex; justify-content: space-between; align-items: center; }
+.nav a { margin-left: 10px; }
+.teams { display: flex; flex-direction: column; align-items: center; }
+.team { margin: 10px 0; text-align: center; }
+.icon { width: 80px; height: 80px; object-fit: contain; margin-bottom: 5px; }
+.post { border: 1px solid #ccc; padding: 10px; margin: 10px 0; }
+.posts { border-collapse: collapse; width: 100%; margin-top: 10px; }
+.posts th, .posts td { border: 1px solid #ccc; padding: 8px; text-align: left; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>KBO Fan Boards</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
+        <div class="nav">
+            {% if nickname %}
+                <span>{{ nickname }}</span>
+                <a href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+                <a href="{{ url_for('login') }}">Login</a>
+                <a href="{{ url_for('register') }}">Sign Up</a>
+            {% endif %}
+        </div>
+    </div>
+    <div class="teams">
+    {% for team in teams %}
+        <div class="team">
+            <a href="{{ url_for('team_board', team=team) }}">
+                <img class="icon" src="{{ logos.get(team) }}" alt="{{ team }} logo">
+                <div class="name">{{ team }}</div>
+            </a>
+        </div>
+    {% endfor %}
+    </div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
+    </div>
+    <h2>Login</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="POST">
+        <input type="text" name="id" placeholder="ID"><br>
+        <input type="password" name="password" placeholder="Password"><br>
+        <button type="submit">Login</button>
+    </form>
+    <a href="{{ url_for('register') }}">Sign Up</a>
+</body>
+</html>

--- a/templates/post.html
+++ b/templates/post.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ post.title }}</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
+        <div class="nav">
+            {% if nickname %}
+                <span>{{ nickname }}</span>
+                <a href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+                <a href="{{ url_for('login') }}">Login</a>
+                <a href="{{ url_for('register') }}">Sign Up</a>
+            {% endif %}
+        </div>
+    </div>
+    <h1>{{ post.title }}</h1>
+    <p><strong>Author:</strong> {{ post.username }}</p>
+    <p>{{ post.content }}</p>
+    {% if post.filename %}
+        <p>Attachment: <a href="{{ url_for('static', filename='uploads/' + team + '/' + post.filename) }}">{{ post.filename }}</a></p>
+    {% endif %}
+    <a href="{{ url_for('team_board', team=team) }}">Back to Board</a>
+</body>
+</html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Register</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
+    </div>
+    <h2>Sign Up</h2>
+    {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+    <form method="POST">
+        <input type="text" name="id" placeholder="ID"><br>
+        <input type="password" name="password" placeholder="Password"><br>
+        <input type="text" name="nickname" placeholder="Nickname"><br>
+        <button type="submit">Register</button>
+    </form>
+</body>
+</html>

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>{{ team }} Board</title>
+    <link rel="stylesheet" href="/static/css/style.css">
+</head>
+<body>
+    <div class="header">
+        <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
+        <div class="nav">
+            {% if nickname %}
+                <span>{{ nickname }}</span>
+                <a href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+                <a href="{{ url_for('login') }}">Login</a>
+                <a href="{{ url_for('register') }}">Sign Up</a>
+            {% endif %}
+        </div>
+    </div>
+    <h1>{{ team }} Fan Board</h1>
+    <a href="{{ url_for('index') }}">Back to Teams</a>
+
+    <h2>New Post</h2>
+    <form method="POST" enctype="multipart/form-data">
+        <input type="text" name="title" placeholder="Title"><br>
+        {% if nickname %}
+            <input type="hidden" name="username" value="{{ nickname }}">
+            <p><strong>Author:</strong> {{ nickname }}</p>
+        {% else %}
+            <input type="text" name="username" placeholder="Your name"><br>
+        {% endif %}
+        <textarea name="content" placeholder="Write your post"></textarea><br>
+        <input type="file" name="file"><br>
+        <button type="submit">Submit</button>
+    </form>
+
+    <h2>Posts</h2>
+    <table class="posts">
+        <tr><th>Title</th><th>Author</th></tr>
+        {% for post in posts %}
+            <tr>
+                <td><a href="{{ url_for('view_post', team=team, post_id=loop.index0) }}">{{ post.title }}</a></td>
+                <td>{{ post.username }}</td>
+            </tr>
+        {% else %}
+            <tr><td colspan="2">No posts yet.</td></tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show KBO teams centered with real logos
- add login, logout and registration pages with session support
- header on each page links back home via '프로야구 응원단'
- posts display author info from login when available

## Testing
- `python3 -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6877a5f48e388321a6c2d6aa1a68a662