### PR TITLE
Apply ranking list updates and logos

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,18 +43,18 @@ TEAM_NAME_MAP = {
     '키움': 'Kiwoom Heroes'
 }
 
-# simple logo mapping (public URLs)
+# logo mapping using the URLs provided by the user
 TEAM_LOGOS = {
-    'Doosan Bears': 'https://sports-phinf.pstatic.net/team/kbo/default/OB.png',
-    'Lotte Giants': 'https://sports-phinf.pstatic.net/team/kbo/default/LT.png',
-    'Hanwha Eagles': 'https://sports-phinf.pstatic.net/team/kbo/default/HH.png',
-    'LG Twins': 'https://sports-phinf.pstatic.net/team/kbo/default/LG.png',
-    'SSG Landers': 'https://sports-phinf.pstatic.net/team/kbo/default/SK.png',
-    'Samsung Lions': 'https://sports-phinf.pstatic.net/team/kbo/default/SS.png',
-    'KIA Tigers': 'https://sports-phinf.pstatic.net/team/kbo/default/HT.png',
-    'KT Wiz': 'https://sports-phinf.pstatic.net/team/kbo/default/KT.png',
-    'NC Dinos': 'https://sports-phinf.pstatic.net/team/kbo/default/NC.png',
-    'Kiwoom Heroes': 'https://sports-phinf.pstatic.net/team/kbo/default/WO.png'
+    'Hanwha Eagles': 'http://www.thesportstimes.co.kr/news/photo/202502/359779_34114_1933.png',
+    'LG Twins': 'https://www.thesportstimes.co.kr/news/photo/202503/361530_34990_2442.png',
+    'KIA Tigers': 'https://www.thesportstimes.co.kr/news/photo/202502/359771_34107_427.png',
+    'Lotte Giants': 'https://www.thesportstimes.co.kr/news/photo/202503/361534_34994_2637.jpg',
+    'KT Wiz': 'https://www.thesportstimes.co.kr/news/photo/202502/359776_34111_647.jpg',
+    'SSG Landers': 'https://www.thesportstimes.co.kr/news/photo/202502/359777_34112_1257.png',
+    'NC Dinos': 'http://www.thesportstimes.co.kr/news/photo/202502/359780_34115_2021.png',
+    'Samsung Lions': 'https://www.thesportstimes.co.kr/news/photo/202503/361529_34989_2416.png',
+    'Doosan Bears': 'https://www.thesportstimes.co.kr/news/photo/202503/361531_34991_2518.png',
+    'Kiwoom Heroes': 'https://www.thesportstimes.co.kr/news/photo/202412/357262_32793_5718.jpg'
 }
 
 def fetch_ranked_teams():
@@ -122,7 +122,9 @@ def index():
     teams = get_ranked_teams()
     username = session.get('username')
     nickname = users.get(username, {}).get('nickname') if username else None
-    return render_template('index.html', teams=teams, username=username, nickname=nickname)
+    return render_template('index.html', teams=teams, logos=TEAM_LOGOS,
+                           username=username, nickname=nickname,
+                           body_class='index')
 
 @app.route('/team/<team>', methods=['GET', 'POST'])
 def team_board(team):

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,10 +1,36 @@
-body { font-family: Arial, sans-serif; margin: 20px; }
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
 .main-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
 .main-header h1 { margin: 0; }
 .main-header .auth a { margin-left: 10px; }
-.teams { display: flex; flex-wrap: wrap; justify-content: center; }
+.teams {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
 .team { margin: 10px; text-align: center; width: 140px; }
 .logo { width: 80px; height: 80px; object-fit: contain; display: block; margin: 0 auto 5px; }
 .post { border: 1px solid #ccc; padding: 10px; margin: 10px 0; }
 .posts { border-collapse: collapse; width: 100%; margin-top: 10px; }
 .posts th, .posts td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+
+/* Background styling for the index page. Replace BACKGROUND_IMAGE_URL with the
+   desired image URL. */
+body.index {
+    background: url('BACKGROUND_IMAGE_URL') no-repeat center center fixed;
+    background-size: cover;
+    position: relative;
+}
+body.index::before {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: inherit;
+    opacity: 0.2;
+    z-index: -1;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
     <title>{{ title or 'KBO Fan Boards' }}</title>
     <link rel="stylesheet" href="/static/css/style.css">
 </head>
-<body>
+<body class="{{ body_class or '' }}">
     <header class="main-header">
         <h1><a href="{{ url_for('index') }}">프로야구 응원단</a></h1>
         <div class="auth">

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,7 +4,7 @@
     {% for team in teams %}
         <div class="team">
             <a href="{{ url_for('team_board', team=team) }}">
-                <img class="logo" src="{{ url_for('static', filename='logos/' + team|lower|replace(' ', '_') + '.svg') }}" alt="{{ team }} logo">
+                <img class="logo" src="{{ logos.get(team) }}" alt="{{ team }} logo">
                 <div class="name">{{ team }}</div>
             </a>
         </div>


### PR DESCRIPTION
## Summary
- update `TEAM_LOGOS` mapping to use URLs from the user
- pass team logos to the index template
- center index page contents and show teams vertically
- allow body to receive CSS classes and prepare background styling

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6877c594cbac83219127107a6c81b7ef